### PR TITLE
Fix issue with Ruby 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ group :jekyll_plugins do
   gem 'jekyll-sitemap'
   gem 'jekyll-paginate-v2'
   gem 'jekyll-datapage-generator'
+  gem "webrick" # Fix for Ruby 3.0.0 https://github.com/jekyll/jekyll/issues/8523
 end


### PR DESCRIPTION
Jekyll 4.2.0 sypie się w Ruby 3.0.0 ponieważ nie ma pakietu webrick out-of-the-box